### PR TITLE
Using Chronic to parse --start and --end command line options

### DIFF
--- a/lib/timetrap/helpers.rb
+++ b/lib/timetrap/helpers.rb
@@ -31,8 +31,8 @@ module Timetrap
       else
         Timetrap::Entry.filter('sheet = ?', Timer.current_sheet)
       end
-      ee = ee.filter('start >= ?', Date.parse(args['-s'])) if args['-s']
-      ee = ee.filter('start <= ?', Date.parse(args['-e']) + 1) if args['-e']
+      ee = ee.filter('start >= ?', Date.parse(Chronic.parse(args['-s']).to_s)) if args['-s']
+      ee = ee.filter('start <= ?', Date.parse(Chronic.parse(args['-e']).to_s) + 1) if args['-e']
       ee
     end
 


### PR DESCRIPTION
Since I'm on a roll... here's another pull request!

This one modifies Timetrap::Helpers.selected_entries to add Chronic parsing of the --start and --end options, passed in with <code>t display</code> and <code>t week</code> commands.

Another really simple change.

-Brian
