### PR TITLE
Check `e.note` exists before calling `rstrip` on it

### DIFF
--- a/lib/timetrap/formatters/text.rb
+++ b/lib/timetrap/formatters/text.rb
@@ -11,7 +11,7 @@ module Timetrap
           h[e.sheet] << e
           h
         end
-        longest_note = entries.inject('Notes'.length) {|l, e| return l if not e.note; [e.note.rstrip.length, l].max}
+        longest_note = entries.inject('Notes'.length) {|l, e| [e.note.to_s.rstrip.length, l].max}
         (sheet_names = sheets.keys.sort).each do |sheet|
           self.output <<  "Timesheet: #{sheet}\n"
           id_heading = Timetrap::CLI.args['-v'] ? 'Id' : '  '


### PR DESCRIPTION
Occasionally I get an error about calling `rstrip` on `nil`. I added one of the two `rstrip`s in the code, so sorry if it was me. I'm not really sure how the error comes about, but I've added a check for mine, and I haven't had an error since.
