### PR TITLE
Require note config

### DIFF
--- a/lib/timetrap/timer.rb
+++ b/lib/timetrap/timer.rb
@@ -119,6 +119,10 @@ module Timetrap
     def start note, time = nil
       raise AlreadyRunning if running?
       time ||= Time.now
+      if Config['require_note'] && note.empty?
+        $stdout.print 'You need to add a note to the entry: '
+        note = $stdin.gets.chomp
+      end
       Entry.create(:sheet => Timer.current_sheet, :note => note, :start => time).save
     end
 


### PR DESCRIPTION
Hey,

I added this to my build, because I want to add a note to everything I do (useful for when clients ask how I spent my time), but I'm really bad at remembering to write one.

If this is something you think would be worth pulling, I'll add spec and documentation first.

P.S. It'd really make most sense in `cli.rb` but I put it in `timer.rb` so it `raise`s `AlreadyRunning` before asking for a note.
