### PR TITLE
Deprecation warning for `t`

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -8,4 +8,8 @@ rescue LoadError
     require File.dirname(__FILE__) + '/../lib/timetrap'
   end
 end
+
+warn "The `t` command is deprecated in favor of `timetrap`, and will be removed in a future version! Sorry for the inconvenience."
+warn "Consider aliasing `timetrap` to `t` if you wish to keep using it with `t` as command."
+warn "You can find the reasoning and more information at https://github.com/samg/timetrap/pull/80."
 Timetrap::CLI.invoke

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1332,5 +1332,12 @@ END:VCALENDAR
       t.read.should == timetrap.read
       t.stat.mode.should == timetrap.stat.mode
     end
+
+    it 'should give a deprecation warning on using t bin' do
+      cmd = File.expand_path(File.join(File.dirname(__FILE__), '..', 'bin', 't')) + ' 2>&1'
+      %x(#{cmd}).should match /The `t` command is deprecated in favor of `timetrap`, and will be removed in a future version! Sorry for the inconvenience\./
+      %x(#{cmd}).should match /.*Consider aliasing `timetrap` to `t` if you wish to keep using it with `t` as command\..*/
+      %x(#{cmd}).should match %r(.*You can find the reasoning and more information at https://github.com/samg/timetrap/pull/80\.)
+    end
   end
 end

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1329,7 +1329,6 @@ END:VCALENDAR
     it 'should include a t bin and an equivalent timetrap bin' do
       timetrap = File.open(File.expand_path(File.join(File.dirname(__FILE__), '..', 'bin', 'timetrap')))
       t = File.open(File.expand_path(File.join(File.dirname(__FILE__), '..', 'bin', 't')))
-      t.read.should == timetrap.read
       t.stat.mode.should == timetrap.stat.mode
     end
 


### PR DESCRIPTION
In addition to PR #80 

Adding deprecation notices. See the reasoning for placement in commit-messages.