### PR TITLE
Run custom ruby scripts as post-command hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,13 @@ Then add this to source the completions:
 fpath=(/path/to/timetrap-1.x.y/gem/completions/zsh $fpath)
 ```
 
+### Callback Hooks
+
+You can extend Timetrap commands by adding your own custom Ruby scripts at
+`~/.timetrap/hooks/#{current_sheet}/#{command}.rb`.
+
+This script will be loaded after the command has finished executing.
+
 Special Thanks
 --------------
 

--- a/lib/timetrap.rb
+++ b/lib/timetrap.rb
@@ -13,6 +13,7 @@ require File.join(File.dirname(__FILE__), 'timetrap', 'cli')
 require File.join(File.dirname(__FILE__), 'timetrap', 'timer')
 require File.join(File.dirname(__FILE__), 'timetrap', 'formatters')
 require File.join(File.dirname(__FILE__), 'timetrap', 'auto_sheets')
+require File.join(File.dirname(__FILE__), 'timetrap', 'hooks')
 module Timetrap
   DB_NAME = defined?(TEST_MODE) ? nil : Timetrap::Config['database_file']
   # connect to database.  This will create one if it doesn't exist

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -41,6 +41,8 @@ COMMAND is one of:
                               you check in or out
       require_note:           Prompt for a note if one isn't provided when
                               checking in
+      hooks_path:             Specify a directory containing callback hook
+                              scripts if not ~/.timetrap/hooks
 
   * display - Display the current timesheet or a specific. Pass `all' as SHEET
       to display all unarchived sheets or `full' to display archived and
@@ -166,6 +168,7 @@ COMMAND is one of:
       else
         handle_invalid_command(command)
       end
+      Timetrap::Hooks.send valid[0]
     end
 
     def valid_command(command)

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -164,11 +164,12 @@ COMMAND is one of:
       command = args.unused.shift
       set_global_options
       case (valid = commands.select{|name| name =~ %r|^#{command}|}).size
-      when 1 then send valid[0]
+      when 1 then
+        send valid[0]
+        Timetrap::Hooks.send valid[0]
       else
         handle_invalid_command(command)
       end
-      Timetrap::Hooks.send valid[0]
     end
 
     def valid_command(command)

--- a/lib/timetrap/config.rb
+++ b/lib/timetrap/config.rb
@@ -35,7 +35,9 @@ module Timetrap
         # automatically check out of any running tasks when checking in.
         'auto_checkout' => false,
         # interactively prompt for a note if one isn't passed when checking in.
-        'require_note' => false
+        'require_note' => false,
+        # default directory to look for event hooks
+        'hooks_path' => "#{ENV['HOME']}/.timetrap/hooks"
       }
     end
 

--- a/lib/timetrap/hooks.rb
+++ b/lib/timetrap/hooks.rb
@@ -2,7 +2,11 @@ module Timetrap
   class Hooks
 
     class << self
-      def method_missing(m, *args)
+
+      __display = instance_method(:display)
+      define_method(:display){ |*args| method_missing(:display, args) }
+
+      def method_missing(m, *args, &block)
         hook = hook_path(Timer.current_sheet, m)
         require hook if File.exist? hook
       end

--- a/lib/timetrap/hooks.rb
+++ b/lib/timetrap/hooks.rb
@@ -1,0 +1,18 @@
+module Timetrap
+  class Hooks
+
+    class << self
+      def method_missing(m, *args)
+        hook = hook_path(Timer.current_sheet, m)
+        require hook if File.exist? hook
+      end
+
+      private
+      def hook_path(command, sheet)
+        path = File.join Timetrap::Config['hooks_path'], command.to_s, sheet.to_s
+        path += '.rb'
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Inspired by `git-hooks`, I've added the concept of callback hooks so that **timetrap** commands can be extended by the end user or through third-party gems.

After any command is finished, if there is a Ruby file at `~/.timetrap/hooks/#{current_sheet}/#{command}.rb`, it will be required before the process exits.

I needed this functionality to support my [timetrap-hipchat](https://github.com/logankoester/timetrap-hipchat) gem, which notifies a chat room when I am billing time and what I'm working on.

![hipchat](https://raw.githubusercontent.com/logankoester/timetrap-hipchat/master/demo.png)

Would love to see this merged in! Let's discuss :smile_cat: 