### PR TITLE
Add --grep option

### DIFF
--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -279,7 +279,7 @@ COMMAND is one of:
                 entry
               when Timer.last_checkout
                 last = Timer.last_checkout
-                warn "Resuming last enrty you checked out of (#{last.note})"
+                warn "Resuming last entry you checked out of (#{last.note})"
                 last
               end
 

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -19,6 +19,7 @@ COMMAND is one of:
     usage: t archive [--start DATE] [--end DATE] [SHEET]
     -s, --start <date:qs>     Include entries that start on this date or later
     -e, --end <date:qs>       Include entries that start on this date or earlier
+    -g, --grep <regexp>       Include entries where the note matches this regexp.
 
   * backend - Open an sqlite shell to the database.
     usage: t backend
@@ -54,6 +55,7 @@ COMMAND is one of:
                               Documentation on defining custom formats can be
                               found in the README included in this
                               distribution.
+    -g, --grep <regexp>       Include entries where the note matches this regexp.
 
   * edit - Alter an entry's note, start, or end time. Defaults to the active
     entry. Defaults to the last entry to be checked out of if no entry is active.
@@ -192,7 +194,7 @@ COMMAND is one of:
     def archive
       ee = selected_entries
       if ask_user "Archive #{ee.count} entries? "
-        ee.all.each do |e|
+        ee.each do |e|
           next unless e.end
           e.update :sheet => "_#{e.sheet}"
         end
@@ -323,7 +325,7 @@ COMMAND is one of:
     end
 
     def display
-      entries = selected_entries.order(:start).all
+      entries = selected_entries
       if entries == []
         warn "No entries were selected to display."
       else

--- a/lib/timetrap/helpers.rb
+++ b/lib/timetrap/helpers.rb
@@ -50,6 +50,11 @@ module Timetrap
       end
       ee = ee.filter('start >= ?', Date.parse(Timer.process_time(args['-s']).to_s)) if args['-s']
       ee = ee.filter('start <= ?', Date.parse(Timer.process_time(args['-e']).to_s) + 1) if args['-e']
+      ee = ee.order(:start)
+      if args['-g']
+        re = Regexp::new(args['-g'])
+        ee = ee.find_all{|e| re.match(e.note)}
+      end
       ee
     end
 

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -88,7 +88,22 @@ describe Timetrap do
       describe 'archive' do
         before do
           3.times do |i|
+            create_entry({:note => 'grep'})
+          end
+          3.times do |i|
             create_entry
+          end
+        end
+
+        it "should only archive entries matched by the provided regex" do
+          $stdin.string = "yes\n"
+          invoke 'archive --grep [g][r][e][p]'
+          Timetrap::Entry.each do |e|
+            if e.note == 'grep'
+              e.sheet.should == '_default'
+            else
+              e.sheet.should == 'default'
+            end
           end
         end
 
@@ -331,6 +346,17 @@ Timesheet: SpecSheet
     Total                                    8:00:00
             OUTPUT
 
+            @desired_output_grepped = <<-OUTPUT
+Timesheet: SpecSheet
+    Day                Start      End        Duration   Notes
+    Fri Oct 03, 2008   12:00:00 - 14:00:00   2:00:00    entry 1
+                                             2:00:00
+    Sun Oct 05, 2008   16:00:00 - 18:00:00   2:00:00    entry 3
+                                             2:00:00
+    -----------------------------------------------------------
+    Total                                    4:00:00
+            OUTPUT
+
             @desired_output_with_ids = <<-OUTPUT
 Timesheet: SpecSheet
 Id  Day                Start      End        Duration   Notes
@@ -405,6 +431,12 @@ Grand Total                                 10:00:00
             )
             invoke 'display Spec'
             $stdout.string.should include("entry 5")
+          end
+
+          it "should only display entries that are matched by the provided regex" do
+            Timetrap::Timer.current_sheet = 'SpecSheet'
+            invoke 'display --grep [13]'
+            $stdout.string.should == @desired_output_grepped
           end
 
           it "should display a timesheet with ids" do


### PR DESCRIPTION
This adds a `--grep <regexp>` (short: `-g`) option to filter entries when using the `t d` or `t a` commands. Only the entries that match the specified regular expression are selected.