### PR TITLE
Update the resume action to allow resuming by id, removes some old functionality

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 * Michael Moen
 * Miles Matthias
 * Devon Blandin (@dblandin)
+* Marc Addeo

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -84,9 +84,10 @@ COMMAND is one of:
     usage: t out [--at TIME] [TIMESHEET]
     -a, --at <time:qs>        Use this time instead of now
 
-  * resume - Start the timer for the current time sheet with the same note as
-      the last entry on the sheet. If there is no entry it takes the passed note.
-    usage: t resume [--at TIME] [NOTES]
+  * resume - Start the timer for the current time sheet for an entry. Defaults
+      to the active entry.
+    usage: t resume [--id ID] [--at TIME] [NOTES]
+    -i, --id <id:i>           Resume entry with id <id> instead of the last entry
     -a, --at <time:qs>        Use this time instead of now
 
   * sheet - Switch to a timesheet creating it if necessary. When no sheet is
@@ -269,13 +270,23 @@ COMMAND is one of:
     end
 
     def resume
-      last_entry = Timer.entries(Timer.current_sheet).last
-      last_entry ||= Timer.entries("_#{Timer.current_sheet}").last
-      warn "No entry yet on this sheet yet. Started a new entry." unless last_entry
-      note = (last_entry ? last_entry.note : nil)
-      warn "Resuming #{note.inspect} from entry ##{last_entry.id}" if note
+      entry = case
+              when args['-i']
+                entry = Entry[args['-i']]
+                warn "Resuming entry with id #{args['-i'].inspect} (#{entry.note})"
+                entry
+              when Timer.last_checkout
+                last = Timer.last_checkout
+                warn "Resuming last enrty you checked out of (#{last.note})"
+                last
+              end
 
-      self.unused_args = note || unused_args
+      unless entry
+        warn "Can't find entry"
+        return
+      end
+
+      self.unused_args = entry.note || unused_args
 
       self.in
     end


### PR DESCRIPTION
This changes the resume action to allow you to either resume by an id,
or resume the last checked out entry.

This removes the functionality that allowed you to change the note on
the last entry, or start a new entry with the new note. IMO the former
should just be accomplished by using the edit action, and the latter
with the in action. I don't think there's any need to duplicate the
functionality of those actions within the resume action.

Addresses #114 

@samg definitely want to open a discussion on this change, as I'm removing some functionality of the resume action. Let me know your thoughts!