### PR TITLE
Add nested_dotfiles auto sheet

### DIFF
--- a/lib/timetrap/auto_sheets/nested_dotfiles.rb
+++ b/lib/timetrap/auto_sheets/nested_dotfiles.rb
@@ -1,0 +1,25 @@
+module Timetrap
+  module AutoSheets
+    #
+    # Check the current dir and all parent dirs for .timetrap-sheet
+    #
+    class NestedDotfiles
+      def check_sheet(dir)
+        dotfile = File.join(dir, '.timetrap-sheet')
+        File.read(dotfile).chomp if File.exist?(dotfile)
+      end
+
+      def sheet
+        dir = Dir.pwd
+        while true do
+            sheet = check_sheet dir
+            break if nil != sheet
+            new_dir = File.expand_path("..", dir)
+            break if new_dir == dir
+            dir = new_dir
+        end
+        return sheet
+      end
+    end
+  end
+end

--- a/spec/dotfile/nested/.timetrap-sheet
+++ b/spec/dotfile/nested/.timetrap-sheet
@@ -1,0 +1,1 @@
+nested-sheet

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -277,6 +277,32 @@ describe Timetrap do
             end
           end
         end
+
+        describe "using nested_dotfiles auto_sheet" do
+          describe 'with a .timetrap-sheet in cwd' do
+            it 'should use sheet defined in dotfile' do
+              Dir.chdir('spec/dotfile') do
+                with_stubbed_config('auto_sheet' => 'nested_dotfiles')
+                Timetrap::Timer.current_sheet.should == 'dotfile-sheet'
+              end
+            end
+            it 'should use top-most sheet found in dir heirarchy' do
+              Dir.chdir('spec/dotfile/nested') do
+                with_stubbed_config('auto_sheet' => 'nested_dotfiles')
+                Timetrap::Timer.current_sheet.should == 'nested-sheet'
+              end
+            end
+          end
+
+          describe 'with no .timetrap-sheet in cwd' do
+            it 'should use sheet defined in ancestor\'s dotfile' do
+              Dir.chdir('spec/dotfile/nested/no-sheet') do
+                with_stubbed_config('auto_sheet' => 'nested_dotfiles')
+                Timetrap::Timer.current_sheet.should == 'nested-sheet'
+              end
+            end
+          end
+        end
       end
 
       describe "backend" do


### PR DESCRIPTION
This pull request adds a new autosheet that looks for the `.timetrap-sheet` file up the dir heirarchy.

```
.
|-- Clients
|   |-- .timetrap-sheet
|   |-- Client A
|   |   |-- .timetrap-sheet
|   |   |-- Project 1
|   |   |-- Project 2
|   |-- Client B
|   |   |-- Project 3
|   |   |-- Project 4
|-- Other dir
```

In the `Project 1` and `Project 2` dirs, the sheet will be loaded from `Clients/Client A/.timetrap-sheet`. In the `Project 3` and `Project 4` dirs, the sheet will be loaded from `Clients/.timetrap-sheet`. Any other dir, e.g. `Other dir` will fall back to the default timetrap configured sheet.