### PR TITLE
Add system editor feature

### DIFF
--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -42,6 +42,8 @@ COMMAND is one of:
                               you check in or out
       require_note:           Prompt for a note if one isn't provided when
                               checking in
+      use_system_editor:      Use the system editor to write notes when
+                              checking in
 
   * display - Display the current timesheet or a specific. Pass `all' as SHEET
       to display all unarchived sheets or `full' to display archived and
@@ -263,8 +265,19 @@ COMMAND is one of:
       end
 
       if Config['require_note'] && !Timer.running? && unused_args.empty?
-        $stderr.print("Please enter a note for this entry:\n> ")
-        self.unused_args = $stdin.gets
+        if Config['use_system_editor'] && ENV['EDITOR']
+          file = Tempfile.new('get_note')
+          begin
+            system("#{ENV['EDITOR']} #{file.path}")
+            self.unused_args = IO.read(file.path)
+          ensure
+             file.close
+             file.unlink
+          end
+        else
+          $stderr.print("Please enter a note for this entry:\n> ")
+          self.unused_args = $stdin.gets
+        end
       end
 
       Timer.start unused_args, args['-a']

--- a/lib/timetrap/config.rb
+++ b/lib/timetrap/config.rb
@@ -35,7 +35,8 @@ module Timetrap
         # automatically check out of any running tasks when checking in.
         'auto_checkout' => false,
         # interactively prompt for a note if one isn't passed when checking in.
-        'require_note' => false
+        'require_note' => false,
+        'use_system_editor' => false
       }
     end
 

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -14,7 +14,7 @@ end
 module Timetrap::StubConfig
   def with_stubbed_config options = {}
     defaults = Timetrap::Config.defaults.dup
-    Timetrap::Config.stub(:[]).and_return do |k|
+    Timetrap::Config.stub(:[]) do |k|
       defaults.merge(options)[k]
     end
     yield if block_given?
@@ -129,9 +129,9 @@ describe Timetrap do
             FileUtils.mkdir_p(ENV['HOME'])
             config_file = ENV['HOME'] + '/.timetrap.yml'
             FileUtils.rm(config_file) if File.exist? config_file
-            File.exist?(config_file).should be_false
+            File.exist?(config_file).should be_falsey
             invoke "configure"
-            File.exist?(config_file).should be_true
+            File.exist?(config_file).should be_truthy
           end
         end
 
@@ -617,17 +617,17 @@ start,end,note,sheet
             invoke 'in'
             invoke 'display --format ical'
 
-            $stdout.string.scan(/BEGIN:VEVENT/).should have(2).item
+            expect($stdout.string.scan(/BEGIN:VEVENT/).size).to eq(2)
           end
 
           it "should filter events by the passed dates" do
             invoke 'display --format ical --start 2008-10-03 --end 2008-10-03'
-            $stdout.string.scan(/BEGIN:VEVENT/).should have(1).item
+            expect($stdout.string.scan(/BEGIN:VEVENT/).size).to eq(1)
           end
 
           it "should not filter events by date when none are passed" do
             invoke 'display --format ical'
-            $stdout.string.scan(/BEGIN:VEVENT/).should have(2).item
+            expect($stdout.string.scan(/BEGIN:VEVENT/).size).to eq(2)
           end
 
           it "should export a sheet to an ical format" do
@@ -868,10 +868,10 @@ END:VCALENDAR
       describe "kill" do
         it "should give me a chance not to fuck up" do
           entry = create_entry
-          lambda do
+          expect do
             $stdin.string = ""
             invoke "kill #{entry.sheet}"
-          end.should_not change(Timetrap::Entry, :count).by(-1)
+          end.not_to change(Timetrap::Entry, :count)
         end
 
         it "should delete a timesheet" do


### PR DESCRIPTION
Hi Sam,

I've created the basic functionality to use the system editor. I've only tested locally (using vim) and it seems to work fine.

I haven't added tests _yet_ as I'm not really sure how best to mock out the use of an external editor. I could just call out to a method which will create the tempfile etc. and then stub it in tests.  Happy to implement that / whatever else you like.

Anyway, let me know if this is what you're after, and thanks for a great gem.

Fixes #101 