### PR TITLE
Add editor feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,10 @@ See ``t configure`` for details.  Currently supported options are:
 
   **auto_sheet_search_paths**: an array of directories to search for user
                               defined auto_sheet classes
+  *note_editor*: The command to start editing notes. Defaults to false which
+               means no external editor is used. Please see the section below
+               on Notes Editing for tips on using non-terminal based editors.
+               Example: note_editor: "vim"
 
 
 ### Autocomplete
@@ -493,6 +497,17 @@ Then add this to source the completions:
 ```bash
 fpath=(/path/to/timetrap-1.x.y/gem/completions/zsh $fpath)
 ```
+
+#### Notes editing
+If you use the note_editor setting, then it is possible to use
+an editor for writing your notes. If you use a non terminal based
+editor (like atom, sublime etc.) then you will need to make timetrap
+wait until the editor has finished. If you're using the "core.editor"
+flag in git, then it'll be the same flags you'll use.
+
+As of when this command was added, for atom you would use `atom --wait`
+and for sublime `subl -w`. If you use a console based editor (vim, emacs,
+nano) then it should just work.
 
 Special Thanks
 --------------

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -42,6 +42,9 @@ COMMAND is one of:
                               you check in or out
       require_note:           Prompt for a note if one isn't provided when
                               checking in
+      note_editor:            Command to launch notes editor or false if no editor use.
+                              If you use a non terminal based editor (e.g. sublime, atom)
+                              please read the notes in the README.
 
   * display - Display the current timesheet or a specific. Pass `all' as SHEET
       to display all unarchived sheets or `full' to display archived and
@@ -263,8 +266,19 @@ COMMAND is one of:
       end
 
       if Config['require_note'] && !Timer.running? && unused_args.empty?
-        $stderr.print("Please enter a note for this entry:\n> ")
-        self.unused_args = $stdin.gets
+        if Config['note_editor']
+          file = Tempfile.new('get_note')
+          begin
+            system("#{Config['note_editor']} #{file.path}")
+            self.unused_args = file.open.read
+          ensure
+             file.close
+             file.unlink
+          end
+        else
+          $stderr.print("Please enter a note for this entry:\n> ")
+          self.unused_args = $stdin.gets
+        end
       end
 
       Timer.start unused_args, args['-a']

--- a/lib/timetrap/config.rb
+++ b/lib/timetrap/config.rb
@@ -35,7 +35,9 @@ module Timetrap
         # automatically check out of any running tasks when checking in.
         'auto_checkout' => false,
         # interactively prompt for a note if one isn't passed when checking in.
-        'require_note' => false
+        'require_note' => false,
+        # command to launch external editor (false if no external editor used)
+        'note_editor' => false
       }
     end
 

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -14,7 +14,7 @@ end
 module Timetrap::StubConfig
   def with_stubbed_config options = {}
     defaults = Timetrap::Config.defaults.dup
-    Timetrap::Config.stub(:[]).and_return do |k|
+    Timetrap::Config.stub(:[]) do |k|
       defaults.merge(options)[k]
     end
     yield if block_given?
@@ -129,9 +129,9 @@ describe Timetrap do
             FileUtils.mkdir_p(ENV['HOME'])
             config_file = ENV['HOME'] + '/.timetrap.yml'
             FileUtils.rm(config_file) if File.exist? config_file
-            File.exist?(config_file).should be_false
+            File.exist?(config_file).should be_falsey
             invoke "configure"
-            File.exist?(config_file).should be_true
+            File.exist?(config_file).should be_truthy
           end
         end
 
@@ -617,17 +617,17 @@ start,end,note,sheet
             invoke 'in'
             invoke 'display --format ical'
 
-            $stdout.string.scan(/BEGIN:VEVENT/).should have(2).item
+            expect($stdout.string.scan(/BEGIN:VEVENT/).size).to eq(2)
           end
 
           it "should filter events by the passed dates" do
             invoke 'display --format ical --start 2008-10-03 --end 2008-10-03'
-            $stdout.string.scan(/BEGIN:VEVENT/).should have(1).item
+            expect($stdout.string.scan(/BEGIN:VEVENT/).size).to eq(1)
           end
 
           it "should not filter events by date when none are passed" do
             invoke 'display --format ical'
-            $stdout.string.scan(/BEGIN:VEVENT/).should have(2).item
+            expect($stdout.string.scan(/BEGIN:VEVENT/).size).to eq(2)
           end
 
           it "should export a sheet to an ical format" do
@@ -868,10 +868,10 @@ END:VCALENDAR
       describe "kill" do
         it "should give me a chance not to fuck up" do
           entry = create_entry
-          lambda do
+          expect do
             $stdin.string = ""
             invoke "kill #{entry.sheet}"
-          end.should_not change(Timetrap::Entry, :count).by(-1)
+          end.not_to change(Timetrap::Entry, :count)
         end
 
         it "should delete a timesheet" do

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -3,6 +3,18 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'timetra
 require 'rspec'
 require 'fakefs/safe'
 
+RSpec.configure do |config|
+  # as we are stubbing stderr and stdout, if you want to capture
+  # any of your output in tests, simply add :write_stdout_stderr => true
+  # as metadata to the end of your test
+  config.after(:each, :write_stdout_stderr => true) do
+    $stderr.rewind
+    $stdout.rewind
+    File.write("stderr.txt", $stderr.read)
+    File.write("stdout.txt", $stdout.read)
+  end
+end
+
 def local_time(str)
   Timetrap::Timer.process_time(str)
 end


### PR DESCRIPTION
Hi Sam,

I've created the basic functionality to use the system editor. I have tested this on my OSX box using vim & emacs & nano.

I haven't added tests yet as I'm not really sure how best to mock out the use of an external editor. I could just call out to a method which will create the tempfile etc. and then stub it in tests. Happy to implement that / whatever else you like.

Anyway, let me know if this is what you're after, and thanks for a great gem.

Fixes #101

p.s. apologies for opening & closing the other PR. I wanted to fix up my use of the `IO.read` (and test in a few of the editors, as someone had suggested the behaviour might be different in something other than vim)