### PR TITLE
Ability to edit notes

### DIFF
--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -274,16 +274,17 @@ COMMAND is one of:
         end
       end
 
+      note = unused_args
       if Config['require_note'] && !Timer.running? && unused_args.empty?
         if Config['note_editor']
-          self.unused_args = get_note_from_external_editor
+          note = get_note_from_external_editor
         else
           $stderr.print("Please enter a note for this entry:\n> ")
-          self.unused_args = $stdin.gets
+          note = $stdin.gets.strip
         end
       end
 
-      Timer.start unused_args, args['-a']
+      Timer.start note, args['-a']
       warn "Checked into sheet #{Timer.current_sheet.inspect}."
     end
 

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -242,14 +242,23 @@ COMMAND is one of:
         entry.update :sheet => args['-m']
       end
 
-      # update notes
-      if unused_args =~ /.+/
-        note = unused_args
+      if Config['note_editor']
         if args['-z']
-          note = [entry.note, note].join(Config['append_notes_delimiter'])
+          note = [entry.note, get_note_from_external_editor].join(Config['append_notes_delimiter'])
+          entry.update :note => note
+        elsif args.size == 0 # no arguments supplied
+          entry.update :note => get_note_from_external_editor(entry.note)
         end
-        entry.update :note => note
+      else
+        if unused_args =~ /.+/
+          note = unused_args
+          if args['-z']
+            note = [entry.note, note].join(Config['append_notes_delimiter'])
+          end
+          entry.update :note => note
+        end
       end
+
 
       puts format_entries(entry)
     end
@@ -267,14 +276,7 @@ COMMAND is one of:
 
       if Config['require_note'] && !Timer.running? && unused_args.empty?
         if Config['note_editor']
-          file = Tempfile.new('get_note')
-          begin
-            system("#{Config['note_editor']} #{file.path}")
-            self.unused_args = file.open.read
-          ensure
-             file.close
-             file.unlink
-          end
+          self.unused_args = get_note_from_external_editor
         else
           $stderr.print("Please enter a note for this entry:\n> ")
           self.unused_args = $stdin.gets
@@ -465,6 +467,21 @@ COMMAND is one of:
       return true if args['-y']
       $stderr.print question
       $stdin.gets =~ /\Aye?s?\Z/i
+    end
+
+    def get_note_from_external_editor(contents = "")
+      file = Tempfile.new('get_note')
+      unless contents.empty?
+        file.open
+        file.write(contents)
+        file.close
+      end
+
+      system("#{Config['note_editor']} #{file.path}")
+      file.open.read
+    ensure
+     file.close
+     file.unlink
     end
 
     extend Helpers::AutoLoad

--- a/lib/timetrap/formatters/text.rb
+++ b/lib/timetrap/formatters/text.rb
@@ -1,22 +1,19 @@
 module Timetrap
   module Formatters
     class Text
+      LONGEST_NOTE_LENGTH = 50
       attr_accessor :output
       include Timetrap::Helpers
 
       def initialize entries
+        @entries = entries
         self.output = ''
         sheets = entries.inject({}) do |h, e|
           h[e.sheet] ||= []
           h[e.sheet] << e
           h
         end
-        longest_note = entries.inject('Notes'.length) {|l, e| [e.note.to_s.rstrip.length, l].max}
-        max_id_length = if Timetrap::CLI.args['-v']
-          entries.inject(3) {|l, e| [e.id.to_s.length, l].max}
-        else
-          3
-        end
+
         (sheet_names = sheets.keys.sort).each do |sheet|
 
           self.output <<  "Timesheet: #{sheet}\n"
@@ -24,7 +21,6 @@ module Timetrap
           self.output <<  "#{id_heading}  Day                Start      End        Duration   Notes\n"
           last_start = nil
           from_current_day = []
-
 
           sheets[sheet].each_with_index do |e, i|
             from_current_day << e
@@ -34,7 +30,7 @@ module Timetrap
               format_time(e.start),
               format_time(e.end),
               format_duration(e.duration),
-              e.note
+              format_note(e.note)
             ]
 
             nxt = sheets[sheet].to_a[i+1]
@@ -53,7 +49,53 @@ module Timetrap
           self.output <<  "%s\n" % ('-'*(4+52+longest_note))
           self.output <<  "Grand Total%41s\n" % format_total(sheets.values.flatten)
         end
+
+
       end
+
+
+      private
+
+      attr_reader :entries
+
+      def longest_note
+        @longest_note ||= begin
+          entries.inject('Notes'.length) {|l, e| [e.note.to_s.rstrip.length, LONGEST_NOTE_LENGTH].min}
+        end
+      end
+
+      def max_id_length
+        @max_id_length ||= begin
+          if Timetrap::CLI.args['-v']
+            entries.inject(3) {|l, e| [e.id.to_s.length, l].max}
+          else
+            3
+          end
+        end
+      end
+
+      def format_note(note)
+        return "" unless note
+
+        lines = []
+        line_number = 0
+        note.lines.each do |line|
+          while index = line.index(/\s/, LONGEST_NOTE_LENGTH) do
+            shorter_line = line.slice!(0..(index - 1))
+            lines << padded_line(shorter_line.strip, line_number)
+            line_number += 1
+          end
+          lines << padded_line(line.strip, line_number)
+          line_number += 1
+        end
+        lines.join("\n")
+      end
+
+      def padded_line(content, line_number)
+        return content if line_number == 0
+        "#{" " * (56 + max_id_length - 3) }#{content}"
+      end
+
     end
   end
 end

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
   # as we are stubbing stderr and stdout, if you want to capture
   # any of your output in tests, simply add :write_stdout_stderr => true
   # as metadata to the end of your test
-  config.after(:each, :write_stdout_stderr => true) do
+  config.after(:each, write_stdout_stderr: true) do
     $stderr.rewind
     $stdout.rewind
     File.write("stderr.txt", $stderr.read)
@@ -839,6 +839,15 @@ END:VCALENDAR
               invoke "in"
               $stderr.string.should_not include('enter a note')
               Timetrap::Timer.active_entry.note.should == "written in editor"
+            end
+
+            it "should preserve linebreaks from editor" do |example|
+              Timetrap::CLI.stub(:system) do |editor_command|
+                path = editor_command.match(/#{note_editor_command} (?<path>.*)/)
+                File.write(path[:path], "line1\nline2")
+              end
+              invoke "in"
+              Timetrap::Timer.active_entry.note.should == "line1\nline2"
             end
           end
         end


### PR DESCRIPTION
Hi Sam,

Here's a PR to add the ability to edit notes using the external editor.

I also slightly tweaked the text formatter so that long lines (and lines with linebreaks) now are displayed a little more nicely. Now that it's possible to insert linebreaks (even likely) in the notes, the text formatting was looking a bit bad. It's not very clever, it just finds the first whitespace after 50 chars and then goes onto the next line. Feel free to nuke it if you don't like it.

Let me know if there's anything you want changed etc.
Best,
Patrick

Relates to PR #131 and extends it to allow editing notes in external editor.