### PR TITLE
raise Timer::AlreadyRunning for CLI.resume

### DIFF
--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -289,6 +289,8 @@ COMMAND is one of:
     end
 
     def resume
+      raise Timer::AlreadyRunning if Timer.running?
+
       entry = case
               when args['-i']
                 entry = Entry[args['-i']]


### PR DESCRIPTION
Previously, if you would resume when already running an entry, timetrap would first print that it's resuming your entry to error after that, this is nicer imo.
