### PR TITLE
Allow configuration to set start of week

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,8 @@ Commands
   usage: ``t yesterday [--ids] [--format FMT] [SHEET | all]``
 
 **week**
-  Shortcut for display with start date set to Monday of this week
+  Shortcut for display with start date set to a day of this week. The default
+  start of the week is Monday.
 
   usage: ``t week [--ids] [--end DATE] [--format FMT] [TIMESHEET | all]``
 
@@ -469,6 +470,7 @@ See ``t configure`` for details.  Currently supported options are:
                on Notes Editing for tips on using non-terminal based editors.
                Example: note_editor: "vim"
 
+  **week_start**: The day of the week to use as the start of the week for t week.
 
 ### Autocomplete
 

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -450,9 +450,10 @@ COMMAND is one of:
       d = Chronic.parse( args['-s'] || Date.today )
 
       today = Date.new( d.year, d.month, d.day )
+      end_of_week = Date.new( d.year, d.month, d.day + 6 )
       last_week_start = Date.parse(Chronic.parse('last '.concat(Config['week_start']).to_s, :now => today).to_s)
       args['-s'] = today.wday == Date.parse(Config['week_start']).wday ? today.to_s : last_week_start.to_s
-      args['-e'] = today.to_s
+      args['-e'] = end_of_week.to_s
       display
     end
 

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -447,7 +447,12 @@ COMMAND is one of:
     end
 
     def week
-      args['-s'] = Date.today.wday == Date.parse(Config['week_start']).wday ? Date.today.to_s : Date.parse(Chronic.parse('last '.concat(Config['week_start'])).to_s).to_s
+      d = Chronic.parse( args['-s'] || Date.today )
+
+      today = Date.new( d.year, d.month, d.day )
+      last_week_start = Date.parse(Chronic.parse('last '.concat(Config['week_start']).to_s, :now => today).to_s)
+      args['-s'] = today.wday == Date.parse(Config['week_start']).wday ? today.to_s : last_week_start.to_s
+      args['-e'] = today.to_s
       display
     end
 

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -45,6 +45,8 @@ COMMAND is one of:
       note_editor:            Command to launch notes editor or false if no editor use.
                               If you use a non terminal based editor (e.g. sublime, atom)
                               please read the notes in the README.
+      week_start:             The day of the week to use as the start of the
+                              week for t week.
 
   * display - Display the current timesheet or a specific. Pass `all' as SHEET
       to display all unarchived sheets or `full' to display archived and
@@ -106,7 +108,9 @@ COMMAND is one of:
   * yesterday - Shortcut for display with start and end dates as the day before the current day
     usage: t yesterday [--ids] [--format FMT] [SHEET | all]
 
-  * week - Shortcut for display with start date set to monday of this week.
+  * week - Shortcut for display with start date set to a day of this week.
+    The default start of the week is Monday.
+.
     usage: t week [--ids] [--end DATE] [--format FMT] [SHEET | all]
 
   * month - Shortcut for display with start date set to the beginning of either
@@ -443,7 +447,7 @@ COMMAND is one of:
     end
 
     def week
-      args['-s'] = Date.today.wday == 1 ? Date.today.to_s : Date.parse(Chronic.parse(%q(last monday)).to_s).to_s
+      args['-s'] = Date.today.wday == Date.parse(Config['week_start']).wday ? Date.today.to_s : Date.parse(Chronic.parse('last '.concat(Config['week_start'])).to_s).to_s
       display
     end
 

--- a/lib/timetrap/config.rb
+++ b/lib/timetrap/config.rb
@@ -37,7 +37,9 @@ module Timetrap
         # interactively prompt for a note if one isn't passed when checking in.
         'require_note' => false,
         # command to launch external editor (false if no external editor used)
-        'note_editor' => false
+        'note_editor' => false,
+        # set day of the week when determining start of the week.
+        'week_start' => "Monday",
       }
     end
 

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1035,6 +1035,28 @@ END:VCALENDAR
             $stdout.string.should_not include 'Jan 31, 2012'
             $stdout.string.should_not include 'Feb 05, 2012'
           end
+
+          it "should not show entries 7 days past start of week" do
+            create_entry(
+              :start => Time.local(2012, 2, 9, 1, 2, 3),
+              :end => Time.local(2012, 2, 9, 2, 2, 3)
+            )
+            create_entry(
+              :start => Time.local(2012, 2, 14, 1, 2, 3),
+              :end => Time.local(2012, 2, 14, 2, 2, 3)
+            )
+            create_entry(
+              :start => Time.local(2012, 2, 16, 1, 2, 3),
+              :end => Time.local(2012, 2, 16, 2, 2, 3)
+            )
+
+            Date.should_receive(:today).and_return(Date.new(2012, 2, 7))
+            invoke 'week'
+
+            $stdout.string.should include 'Feb 09, 2012'
+            $stdout.string.should_not include 'Feb 14, 2012'
+            $stdout.string.should_not include 'Feb 16, 2012'
+          end
         end
       end
 

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -986,6 +986,56 @@ END:VCALENDAR
           $stdout.string.should include Time.now.strftime('%a %b %d, %Y')
           $stdout.string.should_not include 'Feb 01, 2012'
         end
+
+        describe "with week_start config option set" do
+          let(:week_start_config) { 'Tuesday' }
+          before do
+            with_stubbed_config 'week_start' => week_start_config
+          end
+          it "should not show entries prior to defined start of week" do
+            create_entry(
+              :start => Time.local(2012, 2, 5, 1, 2, 3),
+              :end => Time.local(2012, 2, 5, 2, 2, 3)
+            )
+            create_entry(
+              :start => Time.local(2012, 2, 8, 1, 2, 3),
+              :end => Time.local(2012, 2, 8, 2, 2, 3)
+            )
+            create_entry(
+              :start => Time.local(2012, 2, 9, 1, 2, 3),
+              :end => Time.local(2012, 2, 9, 2, 2, 3)
+            )
+
+            Date.should_receive(:today).and_return(Date.new(2012, 2, 9))
+            invoke 'week'
+
+            $stdout.string.should include 'Feb 08, 2012'
+            $stdout.string.should include 'Feb 09, 2012'
+            $stdout.string.should_not include 'Feb 05, 2012'
+          end
+
+          it "should only show entries from today if today is start of week" do
+            create_entry(
+              :start => Time.local(2012, 1, 31, 1, 2, 3),
+              :end => Time.local(2012, 1, 31, 2, 2, 3)
+            )
+            create_entry(
+              :start => Time.local(2012, 2, 5, 1, 2, 3),
+              :end => Time.local(2012, 2, 5, 2, 2, 3)
+            )
+            create_entry(
+              :start => Time.local(2012, 2, 7, 1, 2, 3),
+              :end => Time.local(2012, 2, 7, 2, 2, 3)
+            )
+
+            Date.should_receive(:today).and_return(Date.new(2012, 2, 7))
+            invoke 'week'
+
+            $stdout.string.should include 'Feb 07, 2012'
+            $stdout.string.should_not include 'Jan 31, 2012'
+            $stdout.string.should_not include 'Feb 05, 2012'
+          end
+        end
       end
 
       describe "month" do


### PR DESCRIPTION
Create a week_start variable in the .timetrap.yml configuration file. Maintain the default of Monday as the start of the week when parsing `timetrap week`.

Update help information on `timetrap week` usage.

Pull request for #141. 
