### PR TITLE
Allow external note editor for old entries.

### DIFF
--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -246,7 +246,7 @@ COMMAND is one of:
         if args['-z']
           note = [entry.note, get_note_from_external_editor].join(Config['append_notes_delimiter'])
           entry.update :note => note
-        elsif args.size == 0 # no arguments supplied
+        elsif editing_a_note?
           entry.update :note => get_note_from_external_editor(entry.note)
         end
       else
@@ -490,6 +490,15 @@ COMMAND is one of:
     ensure
      file.close
      file.unlink
+    end
+
+    def editing_a_note?
+      return true if args.size == 0
+
+      args.each do |(k,_v)|
+        return false unless ["--id", "-i"].include?(k)
+      end
+      true
     end
 
     extend Helpers::AutoLoad


### PR DESCRIPTION
At the moment, if you're using the note_editor functionality, if you try to edit an old note by it's id (e.g. `t edit --id 76`) then no editor will be launched.

This PR makes it so that you can edit a note by it's ID and it will launch an editor. It will _only_ launch the external editor if you are either running an empty command `t edit` or when you're launching the edit against an id (`t edit --id 76`), this means that if you're editing the `start` time for example, that the external editor will not be launched, which is the existing behaviour and probably what's the best default.
