### PR TITLE
Improve text formatter behaviour for linebreaks.

### DIFF
--- a/lib/timetrap/formatters/text.rb
+++ b/lib/timetrap/formatters/text.rb
@@ -74,20 +74,22 @@ module Timetrap
         end
       end
 
+      def word_wrap(text, line_width: LONGEST_NOTE_LENGTH, break_sequence: "\n")
+      # https://github.com/rails/rails/blob/df63abe6d31cdbe426ff6dda9bdd878acc602728/actionview/lib/action_view/helpers/text_helper.rb#L258-L262
+
+        text.split("\n").collect! do |line|
+          line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1#{break_sequence}").strip : line
+        end * break_sequence
+      end
+
       def format_note(note)
         return "" unless note
-
+        wrapped_note = word_wrap(note.gsub("\n"," "))
         lines = []
-        line_number = 0
-        note.lines.each do |line|
-          while index = line.index(/\s/, LONGEST_NOTE_LENGTH) do
-            shorter_line = line.slice!(0..(index - 1))
-            lines << padded_line(shorter_line.strip, line_number)
-            line_number += 1
-          end
-          lines << padded_line(line.strip, line_number)
-          line_number += 1
+        wrapped_note.lines.each_with_index do |line, index|
+          lines << padded_line(line.strip, index)
         end
+
         lines.join("\n")
       end
 

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -454,7 +454,7 @@ The "format" command is deprecated in favor of "display". Sorry for the inconven
               :note => 'entry 4', :start => '2008-10-05 18:00:00'
             )
             Timetrap::Entry.create( :sheet => 'LongNoteSheet',
-              :note => "long notesheet " * 20, :start => '2008-10-05 16:00:00', :end => '2008-10-05 18:00:00'
+              :note => test_long_text, :start => '2008-10-05 16:00:00', :end => '2008-10-05 18:00:00'
             )
             Timetrap::Entry.create( :sheet => 'SheetWithLineBreakNote',
               :note => "first line\nand a second line ", :start => '2008-10-05 16:00:00', :end => '2008-10-05 18:00:00'
@@ -515,12 +515,13 @@ Id    Day                Start      End        Duration   Notes
             @desired_output_for_long_note_sheet = <<-OUTPUT
 Timesheet: LongNoteSheet
     Day                Start      End        Duration   Notes
-    Sun Oct 05, 2008   16:00:00 - 18:00:00   2:00:00    long notesheet long notesheet long notesheet long notesheet
-                                                        long notesheet long notesheet long notesheet long
-                                                        notesheet long notesheet long notesheet long notesheet
-                                                        long notesheet long notesheet long notesheet long
-                                                        notesheet long notesheet long notesheet long notesheet
-                                                        long notesheet long notesheet
+    Sun Oct 05, 2008   16:00:00 - 18:00:00   2:00:00    chatting with bob about upcoming task, district
+                                                        sharing of images, how the user settings currently
+                                                        works etc. Discussing the fingerprinting / cache
+                                                        busting issue with CKEDITOR, suggesting perhaps
+                                                        looking into forking the rubygem and seeing if we
+                                                        can work in our own changes, however hard that
+                                                        might be.
                                              2:00:00
     ------------------------------------------------------------------------------------------------------
     Total                                    2:00:00
@@ -529,12 +530,13 @@ Timesheet: LongNoteSheet
             @desired_output_for_long_note_sheet_with_ids = <<-OUTPUT
 Timesheet: LongNoteSheet
 Id    Day                Start      End        Duration   Notes
-60000 Sun Oct 05, 2008   16:00:00 - 18:00:00   2:00:00    long notesheet long notesheet long notesheet long notesheet
-                                                          long notesheet long notesheet long notesheet long
-                                                          notesheet long notesheet long notesheet long notesheet
-                                                          long notesheet long notesheet long notesheet long
-                                                          notesheet long notesheet long notesheet long notesheet
-                                                          long notesheet long notesheet
+60000 Sun Oct 05, 2008   16:00:00 - 18:00:00   2:00:00    chatting with bob about upcoming task, district
+                                                          sharing of images, how the user settings currently
+                                                          works etc. Discussing the fingerprinting / cache
+                                                          busting issue with CKEDITOR, suggesting perhaps
+                                                          looking into forking the rubygem and seeing if we
+                                                          can work in our own changes, however hard that
+                                                          might be.
                                                2:00:00
       ------------------------------------------------------------------------------------------------------
       Total                                    2:00:00
@@ -543,8 +545,7 @@ Id    Day                Start      End        Duration   Notes
             @desired_output_for_note_with_linebreak = <<-OUTPUT
 Timesheet: SheetWithLineBreakNote
     Day                Start      End        Duration   Notes
-    Sun Oct 05, 2008   16:00:00 - 18:00:00   2:00:00    first line
-                                                        and a second line
+    Sun Oct 05, 2008   16:00:00 - 18:00:00   2:00:00    first line and a second line
                                              2:00:00
     --------------------------------------------------------------------------------
     Total                                    2:00:00
@@ -1675,5 +1676,18 @@ END:VCALENDAR
       t.read.should == timetrap.read
       t.stat.mode.should == timetrap.stat.mode
     end
+  end
+
+
+  private
+
+  def test_long_text
+<<TEXT
+chatting with bob about upcoming task, district sharing of images, how the
+user settings currently works etc. Discussing the fingerprinting / cache
+busting issue with CKEDITOR, suggesting perhaps looking into forking the
+rubygem and seeing if we can work in our own changes, however hard that might
+be.
+TEXT
   end
 end


### PR DESCRIPTION
When an external note editor is being used, the user
can easily add linebreaks. When these are displayed in
the terminal though, lining them up is currently a little broken.

For example, given this note text:

`chatting with bob about upcoming task, district sharing of images, how the
user settings currently works etc. Discussing the fingerprinting / cache
busting issue with CKEDITOR, suggesting perhaps looking into forking the
rubygem and seeing if we can work in our own changes, however hard that might
be.`


When this is displayed it (currently) looks like this:


```
60000 Sun Oct 05, 2008   16:00:00 - 18:00:00   2:00:00    chatting with bob about upcoming task, district sharing
                                                          of images, how the
                                                          user settings currently works etc. Discussing the fingerprinting
                                                          / cache
                                                          busting issue with CKEDITOR, suggesting perhaps looking
                                                          into forking the
                                                          rubygem and seeing if we can work in our own changes,
                                                          however hard that might
                                                          be.
```

With this change, we use the ActiveSupport word_wrap method (copied
wholesale) and it does a much nicer job of it

```
60000 Sun Oct 05, 2008   16:00:00 - 18:00:00   2:00:00    chatting with bob about upcoming task, district
                                                          sharing of images, how the user settings currently
                                                          works etc. Discussing the fingerprinting / cache
                                                          busting issue with CKEDITOR, suggesting perhaps
                                                          looking into forking the rubygem and seeing if we
                                                          can work in our own changes, however hard that
                                                          might be.
```
