### PR TITLE
Escape quotes in CSV formatter

### DIFF
--- a/lib/timetrap/formatters/csv.rb
+++ b/lib/timetrap/formatters/csv.rb
@@ -6,13 +6,17 @@ module Timetrap
       def initialize entries
         @output = entries.inject("start,end,note,sheet\n") do |out, e|
           next(out) unless e.end
-          out << %|"#{e.start.strftime(time_format)}","#{e.end.strftime(time_format)}","#{e.note}","#{e.sheet}"\n|
+          out << %|"#{e.start.strftime(time_format)}","#{e.end.strftime(time_format)}","#{escape(e.note)}","#{e.sheet}"\n|
         end
       end
 
       private
       def time_format
         "%Y-%m-%d %H:%M:%S"
+      end
+
+      def escape(note)
+        note.gsub %q{"}, %q{""}
       end
     end
   end

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -722,6 +722,21 @@ start,end,note,sheet
 "2008-10-05 12:00:00","2008-10-05 14:00:00","note","default"
             EOF
           end
+
+          it "should escape quoted notes" do
+            create_entry(
+              :start => local_time_cli('2008-10-07 12:00:00'),
+              :end => local_time_cli('2008-10-07 14:00:00'),
+              :note => %q{"note"}
+            )
+            invoke 'display --format csv'
+            $stdout.string.should == <<-EOF
+start,end,note,sheet
+"2008-10-03 12:00:00","2008-10-03 14:00:00","note","default"
+"2008-10-05 12:00:00","2008-10-05 14:00:00","note","default"
+"2008-10-07 12:00:00","2008-10-07 14:00:00","""note""","default"
+            EOF
+          end
         end
 
         describe 'json' do


### PR DESCRIPTION
If some entries contain double-quotes in their notes after exporting to CSV, it confuses a CSV importer such as spreadsheet software during parsing. For example, Ruby's `csv` gem raises a `CSV::MalformedCSVError` exception.

The proposed modifications are supposed to fix that issue.
