### PR TITLE
Update sequel to silence deprecation warnings

### DIFF
--- a/timetrap.gemspec
+++ b/timetrap.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   # More recent versions of icalendar drop support for Ruby 1.8.7
   spec.add_development_dependency "icalendar", "~> 1.3.0"
   spec.add_development_dependency "json"
-  spec.add_dependency "sequel", "~> 4.0.0"
+  spec.add_dependency "sequel", "~> 4.43.0"
   spec.add_dependency "sqlite3", "~> 1.3.3"
 
   spec.add_dependency "chronic", "~> 0.10.2"


### PR DESCRIPTION
I capture output to generate invoices, so the recent Fixnum/Bignum deprecation is messing up my tooling.