### PR TITLE
Only declare cli options when run as standalone

### DIFF
--- a/lib/timetrap.rb
+++ b/lib/timetrap.rb
@@ -19,7 +19,7 @@ module Timetrap
   # connect to database.  This will create one if it doesn't exist
   DB = Sequel.sqlite DB_NAME
   # only declare cli options when run as standalone
-  if %w[dev_t rspec t timetrap].include?(File.basename($PROGRAM_NAME))
+  if %w[dev_t t timetrap].include?(File.basename($PROGRAM_NAME)) || defined?(TEST_MODE)
     CLI.args = Getopt::Declare.new(<<-EOF)
     #{CLI::USAGE}
     EOF

--- a/lib/timetrap.rb
+++ b/lib/timetrap.rb
@@ -19,7 +19,7 @@ module Timetrap
   # connect to database.  This will create one if it doesn't exist
   DB = Sequel.sqlite DB_NAME
   # only declare cli options when run as standalone
-  if %w[dev_t t timetrap].include?(File.basename($PROGRAM_NAME))
+  if %w[dev_t rspec t timetrap].include?(File.basename($PROGRAM_NAME))
     CLI.args = Getopt::Declare.new(<<-EOF)
     #{CLI::USAGE}
     EOF

--- a/lib/timetrap.rb
+++ b/lib/timetrap.rb
@@ -18,9 +18,12 @@ module Timetrap
   DB_NAME = defined?(TEST_MODE) ? nil : Timetrap::Config['database_file']
   # connect to database.  This will create one if it doesn't exist
   DB = Sequel.sqlite DB_NAME
-  CLI.args = Getopt::Declare.new(<<-EOF)
+  # only declare cli options when run as standalone
+  if %w[dev_t t timetrap].include?(File.basename($PROGRAM_NAME))
+    CLI.args = Getopt::Declare.new(<<-EOF)
     #{CLI::USAGE}
-  EOF
+    EOF
+  end
 end
 require File.expand_path(File.join(File.dirname(__FILE__), 'timetrap', 'schema'))
 require File.expand_path(File.join(File.dirname(__FILE__), 'timetrap', 'models'))


### PR DESCRIPTION
Makes it possible to require timetrap as a gem in another ruby program