### PR TITLE
Formatter: Quota

### DIFF
--- a/lib/timetrap/formatters/quota.rb
+++ b/lib/timetrap/formatters/quota.rb
@@ -1,0 +1,36 @@
+module Timetrap
+  module Formatters
+    class Quota
+      SECONDS_PER_DAY = 8 * 60 * 60
+
+      attr_accessor :output
+      include Timetrap::Helpers
+
+      def initialize(all_entries)
+        output = StringIO.new
+        sheets = all_entries.inject({}) do |h, entry|
+          h[entry.sheet] ||= []
+          h[entry.sheet] << entry
+          h
+        end
+
+        sheets.each do |sheet_name, sheet_entries|
+          output.puts "Timesheet: #{sheet_name}"
+          days = sheet_entries.group_by { |e| e.start.to_date }
+
+          days.each do |date, entries|
+            output.puts "#{date} #{format_duration(entries.map(&:duration).sum)} #{format_duration(SECONDS_PER_DAY)}"
+          end
+
+          logged_duration = sheet_entries.map(&:duration).sum
+          expected_duration = days.size * SECONDS_PER_DAY
+          output.puts
+          output.puts "Total #{format_duration(logged_duration)} #{format_duration(expected_duration)}"
+          output.puts "Balance: #{format_duration(logged_duration - expected_duration)}"
+        end
+
+        self.output = output.string
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey there,

I wanted to thank you a lot for making timetrap. I use it literally every day I work.

Recently (start of the year) I built a formatter that I would use, whenever I wanted to know whether I am working more or less (on average) than I want to (i.e. what my contract says). The quota formatter does just that:

```
$ tt
Timesheet: coding
// --- snip (rest of the year) ---
2020-10-08  8:01:42  8:00:00
2020-10-09  8:04:34  8:00:00
2020-10-12  6:59:42  8:00:00

Total 1219:39:53 1216:00:00
Balance:  3:39:53
```

For each day where at least one entry was logged, it will expect this to be a "presence" day, where 8 hours are required.
Cases like weekends or vacation are covered by not logging anything. Half days of vacation are a little tricky and I would add a "filler" entry of 4 hours.

I found this formatter quite useful to me, so I wanted to try upstreaming it, in case it is useful to someone else.

### Disclaimer

I don't think I would merge this pull request as-is myself just yet. I'd rather see this as a discussion starter.

My questions for now are:
* Is this something that should be part of timetrap at all?
* What would be a good way to configure the working hours per day?
    * would they be defined per sheet
    * ... or on the command-line?
    * ... elsewhere?