### PR TITLE
Don't assume database location in bash completion

### DIFF
--- a/completions/bash/timetrap-autocomplete.bash
+++ b/completions/bash/timetrap-autocomplete.bash
@@ -3,8 +3,9 @@ _timetrap ()
 {
   cur="${COMP_WORDS[COMP_CWORD]}"
   cmd="${COMP_WORDS[1]}"
+
   if [[ ( $cmd = s* || $cmd = d* ) && "$COMP_CWORD" = 2 ]]; then
-    COMPREPLY=($(compgen -W "$(echo "select distinct sheet from entries where sheet not like '\_%';" | sqlite3 ~/.timetrap.db)" $cur))
+    COMPREPLY=($(compgen -W "$(echo "select distinct sheet from entries where sheet not like '\_%';" | t b)" $cur))
     return
   elif [[ "$COMP_CWORD" = 1 ]]; then
     CMDS="archive backend configure display edit in kill list now out resume sheet week month"


### PR DESCRIPTION
Instead let timetrap decide its location based on settings.

This might solve #189 and can be used instead of merging #190 