### PR TITLE
no longer require a specific version of icalendar

### DIFF
--- a/lib/timetrap/formatters/ical.rb
+++ b/lib/timetrap/formatters/ical.rb
@@ -4,7 +4,7 @@ rescue LoadError
   raise <<-ERR
 The icalendar gem must be installed for ical output.
 To install it:
-$ [sudo] gem install icalendar -v"~>1.1.5"
+$ [sudo] gem install icalendar
   ERR
 end
 


### PR DESCRIPTION
Due to the recent changes this specific version of icalendar is not needed. Latest works