### PR TITLE
Formatter 'csv' now follows the '-v' option to include id in the output

### DIFF
--- a/lib/timetrap/formatters/csv.rb
+++ b/lib/timetrap/formatters/csv.rb
@@ -4,9 +4,12 @@ module Timetrap
       attr_reader :output
 
       def initialize entries
-        @output = entries.inject("start,end,note,sheet\n") do |out, e|
+        @output = entries.inject(Timetrap::CLI.args['-v'] ? "id,start,end,note,sheet\n" : "start,end,note,sheet\n") do |out, e|
           next(out) unless e.end
-          out << %|"#{e.start.strftime(time_format)}","#{e.end.strftime(time_format)}","#{escape(e.note)}","#{e.sheet}"\n|
+          if Timetrap::CLI.args['-v']
+            out << %|"#{e.id}",|
+          end
+          out << %|"#{e.start.strftime(time_format)}","#{e.end.strftime(time_format)}","#{e.note}","#{e.sheet}"\n|
         end
       end
 


### PR DESCRIPTION
I noticed that the csv formatter was ignoring the "-v" (or --ids) flag in the display command. This trivial PR makes the csv formatter follow the "-v" option and include the id as the first field in the output.