### PR TITLE
196 round json format

### DIFF
--- a/lib/timetrap/formatters/json.rb
+++ b/lib/timetrap/formatters/json.rb
@@ -16,7 +16,12 @@ module Timetrap
       def initialize entries
         @output = entries.map do |e|
           next unless e.end
-          e.values
+
+          e.values.inject({}) do |h, (k,v)|
+            h[k] = v
+            h[k] = e.public_send(k) if %i[end start].include?(k)
+            h
+          end
         end.compact.to_json
       end
     end

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -33,8 +33,22 @@ module Timetrap::StubConfig
   end
 end
 
+module Timetrap::WithAttributes
+  def with_rounding_on
+    old_round = Timetrap::Entry.round
+    begin
+      Timetrap::Entry.round = true
+      block_return_value = yield
+    ensure
+      Timetrap::Entry.round = old_round
+    end
+  end
+end
+
 describe Timetrap do
   include Timetrap::StubConfig
+  include Timetrap::WithAttributes
+
   before do
     with_stubbed_config
   end
@@ -1695,16 +1709,6 @@ END:VCALENDAR
         it "should have a sheet" do
           @entry.sheet= 'name'
           expect(@entry.sheet).to eq 'name'
-        end
-
-        def with_rounding_on
-          old_val = Timetrap::Entry.round
-          begin
-            Timetrap::Entry.round = true
-            block_return_value = yield
-          ensure
-            Timetrap::Entry.round = old_val
-          end
         end
 
         it "should use round start if the global round attribute is set" do

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -754,7 +754,7 @@ start,end,note,sheet
 
         describe 'json' do
           before do
-            create_entry(:start => local_time_cli('2008-10-03 12:00:00'), :end => local_time_cli('2008-10-03 14:00:00'))
+            create_entry(:start => local_time_cli('2008-10-03 12:07:00'), :end => local_time_cli('2008-10-03 14:08:00'))
             create_entry(:start => local_time_cli('2008-10-05 12:00:00'), :end => local_time_cli('2008-10-05 14:00:00'))
           end
 
@@ -762,8 +762,20 @@ start,end,note,sheet
             invoke 'in'
             invoke 'display -f json'
             expect(JSON.parse($stdout.string)).to eq JSON.parse(<<-EOF)
-[{\"sheet\":\"default\",\"end\":\"#{local_time('2008-10-03 14:00:00')}\",\"start\":\"#{local_time('2008-10-03 12:00:00')}\",\"note\":\"note\",\"id\":1},{\"sheet\":\"default\",\"end\":\"#{local_time('2008-10-05 14:00:00')}\",\"start\":\"#{local_time('2008-10-05 12:00:00')}\",\"note\":\"note\",\"id\":2}]
+[{\"sheet\":\"default\",\"end\":\"#{local_time('2008-10-03 14:08:00')}\",\"start\":\"#{local_time('2008-10-03 12:07:00')}\",\"note\":\"note\",\"id\":1},{\"sheet\":\"default\",\"end\":\"#{local_time('2008-10-05 14:00:00')}\",\"start\":\"#{local_time('2008-10-05 12:00:00')}\",\"note\":\"note\",\"id\":2}]
             EOF
+          end
+
+          context 'with rounding on' do
+            it 'should export to json with rounded output' do
+              with_rounding_on do
+                # rounds to 900s by default
+                invoke 'display -r -f json'
+                expect(JSON.parse($stdout.string)).to eq JSON.parse(<<~EOF)
+                  [{\"sheet\":\"default\",\"end\":\"#{local_time('2008-10-03 14:15:00')}\",\"start\":\"#{local_time('2008-10-03 12:00:00')}\",\"note\":\"note\",\"id\":1},{\"sheet\":\"default\",\"end\":\"#{local_time('2008-10-05 14:00:00')}\",\"start\":\"#{local_time('2008-10-05 12:00:00')}\",\"note\":\"note\",\"id\":2}]
+                EOF
+              end
+            end
           end
         end
 


### PR DESCRIPTION
# What
 - Extracted with_rounding_on test helper into a separate WithAttributes module.
 - Fix JSON formatted output when -r is provided.
 
 # Notes
 
 ✅  Tests added.
 
 Instead of outputting raw data to JSON we make use of model provided values for end and start time.