### PR TITLE
Add edit option to clear note

### DIFF
--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -71,6 +71,7 @@ COMMAND is one of:
     -z, --append              Append to the current note instead of replacing it
                                 the delimiter between appended notes is
                                 configurable (see configure)
+    -c, --clear               Allow an empty note, can be used to clear existing notes
     -m, --move <sheet>        Move to another sheet
 
   * in - Start the timer for the current timesheet.
@@ -247,14 +248,18 @@ COMMAND is one of:
       end
 
       if Config['note_editor']
-        if args['-z']
+        if args['-c']
+          entry.update :note => ''
+        elsif args['-z']
           note = [entry.note, get_note_from_external_editor].join(Config['append_notes_delimiter'])
           entry.update :note => note
         elsif editing_a_note?
           entry.update :note => get_note_from_external_editor(entry.note)
         end
       else
-        if unused_args =~ /.+/
+        if args['-c']
+          entry.update :note => ''
+        elsif unused_args =~ /.+/
           note = unused_args
           if args['-z']
             note = [entry.note, note].join(Config['append_notes_delimiter'])

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -211,6 +211,16 @@ describe Timetrap do
           expect(Timetrap::Timer.active_entry.note).to eq 'running entry//new//more'
         end
 
+        it "should allow clearing the description of the active period" do
+          expect(Timetrap::Timer.active_entry.note).to eq 'running entry'
+          invoke 'edit --clear'
+          expect(Timetrap::Timer.active_entry.note).to eq ''
+          invoke 'edit running entry'
+          expect(Timetrap::Timer.active_entry.note).to eq 'running entry'
+          invoke 'edit -c'
+          expect(Timetrap::Timer.active_entry.note).to eq ''
+        end
+
         it "should edit the start time of the active period" do
           invoke 'edit --start "yesterday 10am"'
           expect(Timetrap::Timer.active_entry.start).to eq Chronic.parse("yesterday 10am")
@@ -338,6 +348,20 @@ describe Timetrap do
               expect(Timetrap::Timer.active_entry.note).to eq 'running entry'
               invoke "edit --append"
               expect(Timetrap::Timer.active_entry.note).to eq 'running entry//appended in editor'
+            end
+          end
+
+          context "clearing" do
+            it "should clear the last entry with -c" do
+              expect(Timetrap::Timer.active_entry.note).to eq 'running entry'
+              invoke "edit -c"
+              expect(Timetrap::Timer.active_entry.note).to eq ''
+            end
+
+            it "should clear the last entry with --clear" do
+              expect(Timetrap::Timer.active_entry.note).to eq 'running entry'
+              invoke "edit --clear"
+              expect(Timetrap::Timer.active_entry.note).to eq ''
             end
           end
         end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Closes: https://github.com/samg/timetrap/issues/164

A new flag (-c or --clear) clears the last entry's note or it can be used with the -i flag to clear another entry's note.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The regex used to see if a note has been provided cannot find empty
strings. It is therefore not possible to look for empty string to clear
a note.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added specs.

Created an entry with a note and cleared it with both `-c` and `--clear`.
Also turned `note_editor` on and confirmed that notes are cleared without the note editor opening again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.