### PR TITLE
Extract spec config to spec_helper and support files

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --profile
+--require spec_helper

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
---color
---profile
 --require spec_helper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ RSpec.configure do |config|
   config.tty = true
 
   # Display 10 slowest tests after a test run
-  config.profile_examples = true
+  config.profile_examples = false
 
   # Use the specified formatter
   # :documentation, :progress, :html, :json, CustomFormatterClass

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ TEST_MODE = true
 # Vendors
 require 'fakefs/safe'
 
+# Load support files from the spec/support directory
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+
 # timetrap
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'timetrap'))
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+RSpec.configure do |config|
+  # Use color in STDOUT
+  config.color = true
+  # Use color not only in STDOUT but also in pagers and files
+  config.tty = true
+
+  # Display 10 slowest tests after a test run
+  config.profile_examples = true
+
+  # Use the specified formatter
+  # :documentation, :progress, :html, :json, CustomFormatterClass
+  config.formatter = :progress
+
+  # Specify order for spec to be run in
+  # TODO: make sure all specs pass when set to :rand
+  # config.order = :rand
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+# Constants
+TEST_MODE = true
+
 RSpec.configure do |config|
   # Use color in STDOUT
   config.color = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,4 +24,14 @@ RSpec.configure do |config|
   # Specify order for spec to be run in
   # TODO: make sure all specs pass when set to :rand
   # config.order = :rand
+
+  # We are stubbing stderr and stdout, if you want to capture
+  # any of your output in tests, simply add :write_stdout_stderr => true
+  # as metadata to the end of your test
+  config.after(:each, write_stdout_stderr: true) do
+    $stderr.rewind
+    $stdout.rewind
+    File.write("stderr.txt", $stderr.read)
+    File.write("stdout.txt", $stdout.read)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # Constants
 TEST_MODE = true
 
+# Vendors
+require 'fakefs/safe'
+
 # timetrap
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'timetrap'))
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 # Constants
 TEST_MODE = true
 
+# timetrap
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'timetrap'))
+
+# Config
 RSpec.configure do |config|
   # Use color in STDOUT
   config.color = true

--- a/spec/support/local_time.rb
+++ b/spec/support/local_time.rb
@@ -1,0 +1,7 @@
+def local_time(str)
+  Timetrap::Timer.process_time(str)
+end
+
+def local_time_cli(str)
+  local_time(str).strftime('%Y-%m-%d %H:%M:%S')
+end

--- a/spec/support/with_rounding_on.rb
+++ b/spec/support/with_rounding_on.rb
@@ -1,0 +1,9 @@
+def with_rounding_on
+  old_round = Timetrap::Entry.round
+  begin
+    Timetrap::Entry.round = true
+    block_return_value = yield
+  ensure
+    Timetrap::Entry.round = old_round
+  end
+end

--- a/spec/support/with_stubbed_config.rb
+++ b/spec/support/with_stubbed_config.rb
@@ -1,0 +1,7 @@
+def with_stubbed_config(options = {})
+  defaults = Timetrap::Config.defaults.dup
+  allow(Timetrap::Config).to receive(:[]) do |k|
+    defaults.merge(options)[k]
+  end
+  yield if block_given?
+end

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1,15 +1,3 @@
-RSpec.configure do |config|
-  # as we are stubbing stderr and stdout, if you want to capture
-  # any of your output in tests, simply add :write_stdout_stderr => true
-  # as metadata to the end of your test
-  config.after(:each, write_stdout_stderr: true) do
-    $stderr.rewind
-    $stdout.rewind
-    File.write("stderr.txt", $stderr.read)
-    File.write("stdout.txt", $stdout.read)
-  end
-end
-
 def local_time(str)
   Timetrap::Timer.process_time(str)
 end

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1,21 +1,8 @@
-module Timetrap::WithAttributes
-  def with_rounding_on
-    old_round = Timetrap::Entry.round
-    begin
-      Timetrap::Entry.round = true
-      block_return_value = yield
-    ensure
-      Timetrap::Entry.round = old_round
-    end
-  end
-end
-
 describe Timetrap do
-  include Timetrap::WithAttributes
-
   before do
     with_stubbed_config
   end
+
   def create_entry atts = {}
     Timetrap::Entry.create({
       :sheet => 'default',

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1,13 +1,3 @@
-module Timetrap::StubConfig
-  def with_stubbed_config options = {}
-    defaults = Timetrap::Config.defaults.dup
-    allow(Timetrap::Config).to receive(:[]) do |k|
-      defaults.merge(options)[k]
-    end
-    yield if block_given?
-  end
-end
-
 module Timetrap::WithAttributes
   def with_rounding_on
     old_round = Timetrap::Entry.round
@@ -21,7 +11,6 @@ module Timetrap::WithAttributes
 end
 
 describe Timetrap do
-  include Timetrap::StubConfig
   include Timetrap::WithAttributes
 
   before do
@@ -1681,7 +1670,6 @@ END:VCALENDAR
 
   describe Timetrap::Entry do
 
-    include Timetrap::StubConfig
     describe "with an instance" do
       before do
         @time = Time.now

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1,11 +1,3 @@
-def local_time(str)
-  Timetrap::Timer.process_time(str)
-end
-
-def local_time_cli(str)
-  local_time(str).strftime('%Y-%m-%d %H:%M:%S')
-end
-
 module Timetrap::StubConfig
   def with_stubbed_config options = {}
     defaults = Timetrap::Config.defaults.dup

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1,4 +1,3 @@
-require 'rspec'
 require 'fakefs/safe'
 
 RSpec.configure do |config|

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1,4 +1,3 @@
-TEST_MODE = true
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'timetrap'))
 require 'rspec'
 require 'fakefs/safe'

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'timetrap'))
 require 'rspec'
 require 'fakefs/safe'
 

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -1,5 +1,3 @@
-require 'fakefs/safe'
-
 RSpec.configure do |config|
   # as we are stubbing stderr and stdout, if you want to capture
   # any of your output in tests, simply add :write_stdout_stderr => true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- I added a spec_helper file.
- Moved config into the spec_helper file.
- Added support files and moved helper functions to support files.
- Turn spec profiling off for simpler spec output.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of the solution for: https://github.com/samg/timetrap/issues/206

- We would like to split the specs into smaller spec files.
- I believe the first step is to take all the config and helper files out of the current spec file.
- With a simpler spec file it will be easier to extract feature and unit tests.

Much inspiration taken from here: https://lokalise.com/blog/how-to-create-a-ruby-gem-testing-suite/

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Automated testing.
This is a refactor so all existing specs still pass.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/3785596/137965043-f7e68d42-cb6d-462c-96c0-0dc157186335.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
