### PR TITLE
added feature for tomorrow as well

### DIFF
--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -456,6 +456,13 @@ COMMAND is one of:
       args['-e'] = yesterday
       display
     end
+      
+    def tomorrow
+      tomorrow = (Date.today + 1).to_s
+      args['-s'] = tomorrow
+      args['-e'] = tomorrow
+      display
+    end
 
     def week
       d = Chronic.parse( args['-s'] || Date.today )

--- a/spec/timetrap_spec.rb
+++ b/spec/timetrap_spec.rb
@@ -989,6 +989,19 @@ END:VCALENDAR
           expect($stdout.string).not_to include Time.now.strftime('%a %b %d, %Y')
         end
       end
+      describe "tomorrow" do
+        it "should only show entries for tomorrow" do
+          tomorrow = Time.now + (24 * 60 * 60)
+          create_entry(
+            :start => tomorrow,
+            :end => tomorrow
+           )
+          create_entry
+          invoke 'tomorrow'
+          expect($stdout.string).to include tomorrow.strftime('%a %b %d, %Y')
+          expect($stdout.string).not_to include Time.now.strftime('%a %b %d, %Y')
+        end
+      end
 
       describe "week" do
         it "should only show entries from this week" do


### PR DESCRIPTION
## Description
I am very new to pull requests, so please forgive me if I have messed up something.
I thought that like 'yesterday', I can also set a schedule ahead in time-trap and can already see in a group what my day would look like the day before. For this reason, I thought of adding the feature for 'tomorrow'.

I am not a Ruby user. I only understand Python but forgive me because I have not conducted the test, but the changes are obvious, I don't think serious testing has to be done.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
