### PR TITLE
updated default message for t out to be clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you make a mistake use the `edit` command.
 You check out with the `out` command.
 
     $ t out
-    Checked out of sheet "coding"
+    Checked out of entry "document timetrap" in sheet "coding"
 
 Running `edit` when you're checked out will edit the last entry you checked out
 of.

--- a/lib/timetrap/cli.rb
+++ b/lib/timetrap/cli.rb
@@ -329,7 +329,8 @@ COMMAND is one of:
     def out
       if Config['auto_checkout']
         stopped = Timer.stop_all(args['-a']).each do |checked_out_of|
-          warn "Checked out of sheet #{checked_out_of.sheet.inspect}."
+          note = Timer.last_checkout.note
+          warn "Checked out of entry #{note.inspect} in sheet #{checked_out_of.sheet.inspect}."
         end
         if stopped.empty?
           warn "No running entries to stop."
@@ -337,7 +338,8 @@ COMMAND is one of:
       else
         sheet = sheet_name_from_string(unused_args)
         if Timer.stop sheet, args['-a']
-          warn "Checked out of sheet #{sheet.inspect}."
+          note = Timer.last_checkout.note
+          warn "Checked out of entry #{note.inspect} in sheet #{sheet.inspect}."
         else
           warn "No running entry on sheet #{sheet.inspect}."
         end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
From issue 105, the default message for the `t out` command can be misleading. The message currently indicates that it checks out of the sheet when it does not.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes: #105 

It gives the user a better understanding of where they are.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since the update is only geared towards changing the wording of an output, the current tests were used. There were 0 failures.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
