### PR TITLE
Loosen sqlite3 dependency

### DIFF
--- a/timetrap.gemspec
+++ b/timetrap.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "icalendar", "~> 2.7"
   spec.add_development_dependency "json", "~> 2.3"
   spec.add_dependency "sequel", "~> 5.30.0"
-  spec.add_dependency "sqlite3", "~> 1.4.2"
+  spec.add_dependency "sqlite3", "~> 1.4"
 
   spec.add_dependency "chronic", "~> 0.10.2"
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Loosen the `sqlite3` dependency to allow versions > 1.4.2 and < 2.0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Restricting `sqlite3` to the `1.4` series is causing installation issues for users on newer Ruby versions. There doesn't seem to be a technical reason for this restriction as `timetrap` still works with later `1.x` `sqlite3` versions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've run `timetrap`'s test suite with multiple `sqlite3` versions, including `1.5.4`, `1.6.9`, and `1.7.3`. Also, using the updated `gemspec`, I've been able to install `timetrap` in Ruby environments that it currently fails to install in.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
