### PR TITLE
Relax sequel and sqlite3 runtime dependency bounds

### DIFF
--- a/timetrap.gemspec
+++ b/timetrap.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   # More recent versions of icalendar drop support for Ruby 1.8.7
   spec.add_development_dependency "icalendar", "~> 2.7"
   spec.add_development_dependency "json", "~> 2.3"
-  spec.add_dependency "sequel", "~> 5.90.0"
-  spec.add_dependency "sqlite3", "~> 1.4"
+  spec.add_dependency "sequel", ">= 5.90", "< 6"
+  spec.add_dependency "sqlite3", ">= 1.4", "< 3"
 
   spec.add_dependency "chronic", "~> 0.10.2"
 end


### PR DESCRIPTION
  ## Summary

  This PR relaxes Timetrap's runtime dependency constraints for `sequel` and `sqlite3`:

  - `sequel`: `~> 5.90.0` -> `>= 5.90, < 6`
  - `sqlite3`: `~> 1.4` -> `>= 1.4, < 3`

  ## Why

  The main motivation is downstream distro packaging.

  I am packaging Timetrap as a dependency for QTimetrap, a desktop UI for Timetrap:
  https://github.com/CyJimmy264/qtimetrap

  On current Fedora, the packaged versions are newer than the currently allowed bounds:

  - `sequel` 5.100.x
  - `sqlite3` 2.x

  With the existing constraints, downstream packagers have to create and maintain compatibility packages for older gem versions even if Timetrap itself works correctly with newer releases.

  Relaxing the bounds makes Timetrap easier to package and distribute in system package repositories, while still keeping the major-version guardrails in place.

  ## Validation

  I validated this change locally with:

  - `sequel 5.102.0`
  - `sqlite3 2.9.2`

  Checks performed:

  - `gem build timetrap.gemspec` succeeds
  - basic database/schema initialization works
  - basic entry lifecycle works:
    - start
    - stop
    - persistence in the SQLite-backed store

  ## Notes

  I could not run the full RSpec suite in this environment because `fakefs` fails during spec boot on Ruby 3.4. That appears unrelated to this dependency change.

  If needed, I can also add a small compatibility note to the changelog or help test against any additional version combinations.
